### PR TITLE
fix code of conduct link

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -3,7 +3,7 @@
 This project is maintained for the benefit of the community, and we're grateful for any contributions to help improve it. We require that contributors:
 
 - Be kind to all 💛
-- Follow the [Code of Conduct](/.github/code-of-conduct.md)
+- Follow the [Code of Conduct](./code-of-conduct.md)
 - Respect the time and effort of maintainers and other contributors
 
 ## What to contribute


### PR DESCRIPTION
Hi. I noticed that the Code of Conduct link is returning 404. It seems that the file has been moved. I think this change should fix the error.

The issue can be observed on the [Contributing](https://github.com/rose-pine/.github/blob/main/contributing.md) page.

You can compare the URLs:
404: https://github.com/rose-pine/.github/blob/main/.github/code-of-conduct.md
200: https://github.com/rose-pine/.github/blob/main/code-of-conduct.md

The fix is my best guess and I suggest you to double-check it.