### PR TITLE
fix links to use uppercase filenames

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 This project is maintained for the benefit of the community, and we're grateful for any contributions to help improve it. We require that contributors:
 
 - Be kind to all 💛
-- Follow the [Code of Conduct](./code-of-conduct.md)
+- Follow the [Code of Conduct](./CODE_OF_CONDUCT.md)
 - Respect the time and effort of maintainers and other contributors
 
 ## What to contribute

--- a/profile/README.md
+++ b/profile/README.md
@@ -14,7 +14,7 @@
   ·
   <a href="https://rosepinetheme.com/palette">Palette</a>
   ·
-  <a href="https://github.com/rose-pine/.github/blob/main/contributing.md">Contributing</a>
+  <a href="https://github.com/rose-pine/.github/blob/main/CONTRIBUTING.md">Contributing</a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
After commit 0ca10384ef33386feedf5513f781e5a41469584f, some file links stopped working.